### PR TITLE
chore(script): 补充 generateUtility 逻辑

### DIFF
--- a/scripts/generateUtility.ts
+++ b/scripts/generateUtility.ts
@@ -2,100 +2,142 @@ import exec from 'execa'
 import fs from 'fs-extra'
 import globby from 'globby'
 import prompts, { Choice } from 'prompts'
-import { basename, join } from 'path'
+import { basename, extname, join } from 'path'
+import { camelCase, capitalize, } from 'lodash-uni'
+import { format, Options } from 'prettier'
+import { getPrettierConfig } from 'haoma'
 
-async function main(rootDir: string) {
-  const srcDir = join(rootDir, './src')
+const ROOTDIR = join(__dirname, '..')
+const SRCDIR = join(ROOTDIR, './src')
 
-  const cats = (
-    await globby('*', {
-      cwd: srcDir,
-      onlyDirectories: true,
+const formatOptions: Options = getPrettierConfig({ parser: 'babel' }, ROOTDIR)
+
+const spaces = globby.sync('*', { cwd: SRCDIR, onlyDirectories: true }).map(path => basename(path))
+
+const checkMethodNameExiste = (spaceName: string, methodName: string): boolean =>
+  globby
+    .sync([`${SRCDIR}/${spaceName}/*.ts`, `!${SRCDIR}/${spaceName}/*.test.ts`], { onlyFiles: true })
+    .map(path => basename(path).replace(extname(path), ''))
+    .includes(methodName)
+
+const interactiveOptions = () => prompts([
+  {
+    name: 'spaces',
+    type: 'select',
+    choices: spaces.map<Choice>((space) => ({
+      title: space, value: space,
+    })),
+    message: '选择工具所属分类',
+  },
+  {
+    name: 'methodName',
+    type: 'text',
+    message: '输入要创建的工具名称',
+  },
+])
+
+const generateTypeFileBody = (methodName: string) => {
+  const body = `
+  /**
+   * ${methodName}。
+   */
+  export type ${methodName} = {}`
+
+  return format(body, formatOptions)
+}
+
+const generateClassFileBody = (methodName: string) => {
+  const body = `
+  /**
+   * ${methodName}。
+   */
+  export class ${methodName}  {}`
+
+  return format(body, formatOptions)
+}
+
+const generateFuncFileBody = (methodName: string) => {
+  const body = `
+    /**
+     * ${methodName}。
+     *
+     * @param value 值
+     * @returns 返回结果
+     */
+    export function ${methodName}(value: any): number {
+      const res = 1
+      return res
+    }`
+
+  return format(body, formatOptions)
+}
+
+const generateUnitTestFileBody = (methodName: string): string => {
+  const body = `
+  import { ${methodName} } from './${methodName}'
+
+  describe('${methodName}', () => {
+    test('ok', () => {
+      expect(${methodName}).toBe(${methodName})
     })
-  ).map(cat => basename(cat))
+  })
+  `
+  return format(body, formatOptions)
+}
 
-  const { cat, name: util } = await prompts([
-    {
-      name: 'cat',
-      type: 'select',
-      choices: cats.map<Choice>(cat => ({
-        title: cat,
-        value: cat,
-      })),
-      message: '选择工具所属分类',
-    },
-    {
-      name: 'name',
-      type: 'text',
-      message: '输入要创建的工具名称',
-    },
-  ])
+async function main (): Promise<any> {
 
-  if (!cat || !util) return
+  const tasks: Array<{ filePath: string, content: string }> = []
 
-  const utilsDir = join(srcDir, `./${cat}`)
-  const utilFile = join(utilsDir, `${util}.ts`)
-  const utilTestFile = join(utilsDir, `${util}.test.ts`)
+  const { spaces, methodName } = await interactiveOptions()
 
-  const isType = cat === 'types'
-  const isClass = !isType && /^[A-Z]/.test(util)
+  const isType = spaces === 'types'
+  const isClass = !isType && /^[A-Z]/.test(methodName)
+  const utilsDir = join(SRCDIR, spaces)
 
-  console.log('开始写入文件...')
+  const processMethodName = isClass ? capitalize(camelCase(methodName)) : camelCase(methodName)
 
-  await Promise.all([
-    fs.writeFile(
-      utilFile,
-      isType
-        ? `
-          /**
-           * ${util}。
-           */
-          export type ${util} = {}
-        `
-        : isClass
-        ? `
-          /**
-           * ${util}。
-           */
-          export class ${util} {
+  if (checkMethodNameExiste(spaces, processMethodName))
+    return Promise.reject(
+      new Error(`${methodName === processMethodName
+        ? methodName
+        : `${methodName}(修正后:${processMethodName})`}在src/${spaces}目录中已存在!
+      `))
 
-          }
-        `
-        : `
-          /**
-           * ${util}。
-           *
-           * @param value 值
-           * @returns 返回结果
-           */
-          export function ${util}(value: any): number {
-            const res = 1
-            return res
-          }
-        `,
-    ),
-    isType
-      ? Promise.resolve()
-      : fs.writeFile(
-          utilTestFile,
-          `
-            import { ${util} } from './${util}'
+  if (isType) {
+    tasks.push({
+      filePath: join(utilsDir, `${processMethodName}.ts`),
+      content: generateTypeFileBody(processMethodName)
+    })
+  }
+  else {
+    if (isClass) {
+      tasks.push({
+        filePath: join(utilsDir, `${processMethodName}.ts`),
+        content: generateClassFileBody(processMethodName)
+      })
+    }
+    else {
+      tasks.push({
+        filePath: join(utilsDir, `${processMethodName}.ts`),
+        content: generateFuncFileBody(processMethodName)
+      })
+    }
+    tasks.push({
+      filePath: join(utilsDir, `${processMethodName}.test.ts`),
+      content: generateUnitTestFileBody(processMethodName)
+    })
+  }
 
-            describe('${util}', () => {
-              test('ok', () => {
-                expect(${util}).toBe(${util})
-              })
-            })
-          `,
-        ),
-  ])
-
-  console.log('✔️ 写入文件成功')
+  for await (const { filePath, content } of tasks) {
+    fs.writeFileSync(filePath, content, { encoding: 'utf-8' })
+    console.log(`✔️ ${filePath}`)
+  }
 
   await exec('npm', ['run', 'generate-index'], {
-    cwd: rootDir,
+    cwd: ROOTDIR,
     stdio: 'inherit',
   })
 }
 
-main(join(__dirname, '..'))
+main()


### PR DESCRIPTION
**解决问题:**

-  未判断方法名是否重名, 重名会直接覆盖。
-  维护 code 比较繁琐,  使用 `prettier.format` 进行格式化。
-  未判断方法名是否合法，用 `lodash.camelCase` 和 `lodash.capitalize` 进行格式化， 在 format 时会对方法名校验(不符合规则, 直接抛出错误)